### PR TITLE
Prefer official asdf manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,7 @@
     "config:base",
     ":dependencyDashboard",
     "github>aquaproj/aqua-renovate-config#1.2.6",
-    "github>aquaproj/aqua-renovate-config:installer-script#1.2.6(cookbooks/aqua/default.rb)",
-    "github>kachick/renovate-config-asdf#1.11.0"
+    "github>aquaproj/aqua-renovate-config:installer-script#1.2.6(cookbooks/aqua/default.rb)"
   ],
   "labels": ["dependencies", "renovate"],
   "packageRules": [


### PR DESCRIPTION
Thanks for using my project! I found this repository when searched in GitHub.
Renovate merged it as https://github.com/renovatebot/renovate/pull/18612.
Now asdf section lists all managed tools as https://github.com/holidayworking/dotfiles/issues/3.  And #188 and #190 are conflicted. 

Feel free to merge or close this PR!

https://github.com/kachick/renovate-config-asdf/pull/388

